### PR TITLE
The line showing "Check the mailing list or irc" links to linux.com

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 			<li><a href="https://plus.google.com/communities/102481350405972365888" title="SWLUG on Google Plus"><i class="icon-google-plus-sign"></i> Google Plus</a></li>
 			<li><a href="https://github.com/organizations/SWLUG/" title="SWLUG on GitHub"><i class="icon-github"></i> Github</a></li>
 			<li><a href="https://www.linkedin.com/groups/SWLUG-4916922" title="SWLUG on LinkedIn"><i class="icon-linkedin-sign"></i> LinkedIn</a></li>
-			<li><a href="http://www.linux.com" title="Linux"><i class="icon-beer"></i> Check the Mailing List or IRC for the next meet</a></li>
+			<li><i class="icon-beer"></i> Check the <a href="http://swlug.org/mailman/listinfo/" title="SWLUG Mailing Lists">Mailing List</a> or <a href="http://irc.lc/oftc/swlug/swlug_newbie" title="The IRC channel">IRC</a> for the next meet</a></li>
 			</ul>
 		</nav>
 	</section>


### PR DESCRIPTION
This is amended to point to the correct URLs for the ML and IRC (from previous in the list)
