### PR TITLE
Fix broken GitHub page link

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 			<li><a href="http://irc.lc/oftc/swlug/swlug_newbie" title="The IRC channel"><i class="icon-comments"></i> Chat - irc.oftc.net: #swlug</a></li>
 			<li><a href="http://twitter.com/SWLUG" title="SWLUG on Twitter"><i class="icon-twitter"></i> Twitter</a></li>
 			<li><a href="https://plus.google.com/communities/102481350405972365888" title="SWLUG on Google Plus"><i class="icon-google-plus-sign"></i> Google Plus</a></li>
-			<li><a href="https://github.com/organizations/SWLUG/" title="SWLUG  on GitHub"><i class="icon-github"></i> Github</a></li>
+			<li><a href="https://github.com/SWLUG" title="SWLUG on GitHub"><i class="icon-github"></i> Github</a></li>
 			<li><a href="https://www.linkedin.com/groups/SWLUG-4916922" title="SWLUG on LinkedIn"><i class="icon-linkedin-sign"></i> LinkedIn</a></li>
 			<li><i class="icon-beer"></i> Check the <a href="http://mailman.lug.org.uk/mailman/listinfo/swlug" title="SWLUG Mailing Lists">Mailing List</a> or <a href="http://irc.lc/oftc/swlug/swlug_newbie" title="The IRC channel">IRC</a> for the next meet</a></li>
 			</ul>


### PR DESCRIPTION
Existing link was pointing to the organisation dashboard (which is only visible to org members).